### PR TITLE
Add metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/shimmerglass/http-mirror-pipeline
 
-go 1.14
+go 1.15
 
 require (
 	github.com/criteo/haproxy-spoe-go v0.0.0-20200316091946-77af26564f0f
 	github.com/gogo/protobuf v1.2.1
 	github.com/google/gopacket v1.1.18
+	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.13.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -24,11 +24,13 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -83,6 +85,7 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -150,6 +153,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
+github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
@@ -157,6 +162,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -215,12 +221,14 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
@@ -232,6 +240,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -340,6 +349,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
+golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -383,6 +394,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/shimmerglass/http-mirror-pipeline/mirror/modules/control"
 	_ "github.com/shimmerglass/http-mirror-pipeline/mirror/modules/sink"
 	_ "github.com/shimmerglass/http-mirror-pipeline/mirror/modules/source"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/server"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,11 +29,21 @@ func main() {
 		log.Fatalf("cannot open config file: %s", err)
 	}
 
-	module, err := config.Create(f)
+	cfg, err := config.Create(f)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for range module.Output() {
+	if cfg.ListenAddr != "" {
+		srv := server.New(cfg.ListenAddr)
+		go func() {
+			err := srv.Run()
+			if err != nil {
+				log.Error(err)
+			}
+		}()
+	}
+
+	for range cfg.Pipeline.Output() {
 	}
 }

--- a/mirror/config/module.go
+++ b/mirror/config/module.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/shimmerglass/http-mirror-pipeline/mirror"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/registry"
+)
+
+var moduleIndex = map[string]int{}
+
+type Module struct {
+	Type   string
+	Name   string
+	Config json.RawMessage
+}
+
+func CreateModule(b []byte) (mirror.Module, error) {
+	mc := Module{}
+	err := json.Unmarshal(b, &mc)
+	if err != nil {
+		return nil, fmt.Errorf("error reading module config: %w", err)
+	}
+
+	name := mc.Name
+	if name == "" {
+		name = fmt.Sprintf("%s.%d", mc.Type, moduleIndex[mc.Type])
+	}
+	moduleIndex[mc.Type]++
+
+	ctx := mirror.ModuleContext{
+		Name: name,
+	}
+
+	return registry.Create(mc.Type, ctx, mc.Config)
+}
+
+func CreateModules(b []byte) ([]mirror.Module, error) {
+	res := []mirror.Module{}
+
+	c := []json.RawMessage{}
+	err := json.Unmarshal(b, &c)
+	if err != nil {
+		return nil, fmt.Errorf("error reading module config: %w", err)
+	}
+
+	for _, mc := range c {
+		mod, err := CreateModule(mc)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, mod)
+	}
+
+	return res, nil
+}

--- a/mirror/module.go
+++ b/mirror/module.go
@@ -1,5 +1,9 @@
 package mirror
 
+type ModuleContext struct {
+	Name string
+}
+
 type Module interface {
 	SetInput(<-chan Request)
 	Output() <-chan Request

--- a/mirror/modules/control/fanout_test.go
+++ b/mirror/modules/control/fanout_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFanout(t *testing.T) {
-	mod, err := NewFanout([]byte(`[
+	mod, err := NewFanout(mirror.ModuleContext{}, []byte(`[
 		{"type": "control.identity", "config": {}},
 		{"type": "control.identity", "config": {}}
 	]`))

--- a/mirror/modules/control/identity.go
+++ b/mirror/modules/control/identity.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"github.com/shimmerglass/http-mirror-pipeline/mirror"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/modules"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror/registry"
 )
 
@@ -14,11 +15,12 @@ func init() {
 }
 
 type Identity struct {
+	ctx     mirror.ModuleContext
 	out     chan mirror.Request
 	modules []mirror.Module
 }
 
-func NewIdentity(cfg []byte) (mirror.Module, error) {
+func NewIdentity(ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
 	return &Identity{
 		out: make(chan mirror.Request),
 	}, nil
@@ -31,6 +33,7 @@ func (m *Identity) Output() <-chan mirror.Request {
 func (m *Identity) SetInput(c <-chan mirror.Request) {
 	go func() {
 		for r := range c {
+			modules.RequestsTotal.WithLabelValues(m.ctx.Name).Inc()
 			m.out <- r
 		}
 		close(m.out)

--- a/mirror/modules/control/seq.go
+++ b/mirror/modules/control/seq.go
@@ -1,9 +1,8 @@
 package control
 
 import (
-	"encoding/json"
-
 	"github.com/shimmerglass/http-mirror-pipeline/mirror"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/config"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror/registry"
 )
 
@@ -15,30 +14,20 @@ func init() {
 	registry.Register(SeqName, NewSeq)
 }
 
-type SeqConfigEl struct {
-	Type   string `json:"type"`
-	Config json.RawMessage
-}
-
 type Seq struct {
+	ctx     mirror.ModuleContext
 	out     <-chan mirror.Request
 	modules []mirror.Module
 }
 
-func NewSeq(cfg []byte) (mirror.Module, error) {
-	c := []SeqConfigEl{}
-	err := json.Unmarshal(cfg, &c)
+func NewSeq(ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
+	mods, err := config.CreateModules(cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	var lastOut <-chan mirror.Request
-	for _, m := range c {
-		sub, err := registry.Create(m.Type, []byte(m.Config))
-		if err != nil {
-			return nil, err
-		}
-
+	for _, sub := range mods {
 		if lastOut != nil {
 			sub.SetInput(lastOut)
 		}
@@ -46,7 +35,10 @@ func NewSeq(cfg []byte) (mirror.Module, error) {
 		lastOut = sub.Output()
 	}
 
-	return &Seq{out: lastOut}, nil
+	return &Seq{
+		ctx: ctx,
+		out: lastOut,
+	}, nil
 }
 
 func (m *Seq) Output() <-chan mirror.Request {

--- a/mirror/modules/metrics.go
+++ b/mirror/modules/metrics.go
@@ -1,0 +1,13 @@
+package modules
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "requets_total",
+		Help: "The total number of requets handled by the module",
+	}, []string{"module"})
+)

--- a/mirror/modules/sink/file_test.go
+++ b/mirror/modules/sink/file_test.go
@@ -16,7 +16,7 @@ func TestFileJSON(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
-	mod, err := NewFile([]byte(`{"path": "` + f.Name() + `", "format": "json"}`))
+	mod, err := NewFile(mirror.ModuleContext{}, []byte(`{"path": "`+f.Name()+`", "format": "json"}`))
 	require.NoError(t, err)
 
 	reqs := []mirror.Request{

--- a/mirror/modules/sink/sink_http_bench_test.go
+++ b/mirror/modules/sink/sink_http_bench_test.go
@@ -15,8 +15,8 @@ func BenchmarkHTTP(b *testing.B) {
 		rw.Write(res)
 	}))
 
-	mod, err := NewHTTP([]byte(`{
-		"target_url": "` + server.URL + `",
+	mod, err := NewHTTP(mirror.ModuleContext{}, []byte(`{
+		"target_url": "`+server.URL+`",
 		"timeout": "10s",
 		"parallel": 10
 	}`))

--- a/mirror/modules/sink/sink_http_test.go
+++ b/mirror/modules/sink/sink_http_test.go
@@ -17,7 +17,7 @@ func TestHTTP(t *testing.T) {
 		assert.Equal(t, r.Header["X-Other-Header"], []string{"value3"})
 	}))
 
-	mod, err := NewHTTP([]byte(`{"target_url": "` + server.URL + `", "timeout": "10s"}`))
+	mod, err := NewHTTP(mirror.ModuleContext{}, []byte(`{"target_url": "`+server.URL+`", "timeout": "10s"}`))
 	require.NoError(t, err)
 
 	in := make(chan mirror.Request, 1)

--- a/mirror/modules/source/haproxy_spoe.go
+++ b/mirror/modules/source/haproxy_spoe.go
@@ -7,6 +7,7 @@ import (
 
 	spoe "github.com/criteo/haproxy-spoe-go"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/modules"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror/registry"
 	log "github.com/sirupsen/logrus"
 )
@@ -25,11 +26,13 @@ type HAProxySPOEConfig struct {
 
 type HAProxySPOE struct {
 	cfg HAProxySPOEConfig
+	ctx mirror.ModuleContext
 	out chan mirror.Request
 }
 
-func NewHAProxySPOE(cfg []byte) (mirror.Module, error) {
+func NewHAProxySPOE(ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
 	mod := &HAProxySPOE{
+		ctx: ctx,
 		out: make(chan mirror.Request),
 	}
 
@@ -136,6 +139,7 @@ func (m *HAProxySPOE) handleMessage(args []spoe.Message) ([]spoe.Action, error) 
 			req.Headers[name] = mirror.HeaderValues{Values: values}
 		}
 
+		modules.RequestsTotal.WithLabelValues(m.ctx.Name).Inc()
 		m.out <- req
 	}
 

--- a/mirror/modules/source/haproxy_spoe_test.go
+++ b/mirror/modules/source/haproxy_spoe_test.go
@@ -87,7 +87,7 @@ func TestHAProxySPOE(t *testing.T) {
 			require.NoError(t, err)
 			defer os.RemoveAll(name)
 
-			mod, err := NewHAProxySPOE([]byte(`{"listen_addr": "@` + name + `spoe.sock"}`))
+			mod, err := NewHAProxySPOE(mirror.ModuleContext{}, []byte(`{"listen_addr": "@`+name+`spoe.sock"}`))
 			require.NoError(t, err)
 
 			go func() {

--- a/mirror/modules/source/pcap.go
+++ b/mirror/modules/source/pcap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror"
+	"github.com/shimmerglass/http-mirror-pipeline/mirror/modules"
 	"github.com/shimmerglass/http-mirror-pipeline/mirror/registry"
 	log "github.com/sirupsen/logrus"
 )
@@ -64,12 +65,14 @@ type PCapConfig struct {
 
 type PCap struct {
 	cfg  PCapConfig
+	ctx  mirror.ModuleContext
 	out  chan mirror.Request
 	buff *bytes.Buffer
 }
 
-func NewPCap(cfg []byte) (mirror.Module, error) {
+func NewPCap(ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
 	mod := &PCap{
+		ctx:  ctx,
 		out:  make(chan mirror.Request),
 		buff: &bytes.Buffer{},
 	}
@@ -136,6 +139,7 @@ func (m *PCap) start() error {
 				continue
 			}
 
+			modules.RequestsTotal.WithLabelValues(m.ctx.Name).Inc()
 			m.out <- req
 		}
 	}()

--- a/mirror/registry/global.go
+++ b/mirror/registry/global.go
@@ -4,10 +4,10 @@ import "github.com/shimmerglass/http-mirror-pipeline/mirror"
 
 var DefaultRegistry = New()
 
-func Register(name string, create FactoryFunc) {
-	DefaultRegistry.Register(name, create)
+func Register(moduleType string, create FactoryFunc) {
+	DefaultRegistry.Register(moduleType, create)
 }
 
-func Create(name string, cfg []byte) (mirror.Module, error) {
-	return DefaultRegistry.Create(name, cfg)
+func Create(moduleType string, ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
+	return DefaultRegistry.Create(moduleType, ctx, cfg)
 }

--- a/mirror/registry/registry.go
+++ b/mirror/registry/registry.go
@@ -6,7 +6,7 @@ import (
 	"github.com/shimmerglass/http-mirror-pipeline/mirror"
 )
 
-type FactoryFunc func(cfg []byte) (mirror.Module, error)
+type FactoryFunc func(ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error)
 
 type Registry struct {
 	modules map[string]FactoryFunc
@@ -25,15 +25,15 @@ func (r *Registry) Register(name string, create FactoryFunc) {
 	r.modules[name] = create
 }
 
-func (r *Registry) Create(name string, cfg []byte) (mirror.Module, error) {
-	c, ok := r.modules[name]
+func (r *Registry) Create(moduleType string, ctx mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
+	c, ok := r.modules[moduleType]
 	if !ok {
-		return nil, fmt.Errorf("module %q does not exist", name)
+		return nil, fmt.Errorf("module %q does not exist", moduleType)
 	}
 
-	m, err := c(cfg)
+	m, err := c(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating module %q: %s", name, err)
+		return nil, fmt.Errorf("error creating module %q: %s", moduleType, err)
 	}
 
 	return m, nil

--- a/mirror/server/server.go
+++ b/mirror/server/server.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+type Server struct {
+	listenAddr string
+}
+
+func New(listenAddr string) *Server {
+	return &Server{
+		listenAddr: listenAddr,
+	}
+}
+
+func (s *Server) Run() error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/health", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("OK"))
+	}))
+
+	log.Infof("%s: listening on %s", os.Args[0], s.listenAddr)
+	return http.ListenAndServe(s.listenAddr, mux)
+}


### PR DESCRIPTION
Add per-module metrics. Since a module can be used multiple times in the
same pipeline, a new "name" parameter in module configuration to
differentiate between them. If no name is specified, one is generated
automatically.
This change also centralize module creation.